### PR TITLE
insert converting to UTF-8 in clean_up()

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -16,6 +16,7 @@
 #include <curses.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <iconv.h>
 
 #include "rogue.h"
 #include "init.h"
@@ -166,6 +167,14 @@ player_init(void)
 void
 clean_up(char *estr)
 {
+    size_t inleft=strlen(estr), outleft=1024;
+    char *inptr= estr;
+    char *outbuf=malloc(outleft);
+    memset(outbuf, 0, 1024);
+    char *outptr=outbuf;
+    iconv_t conv = iconv_open("UTF-8//TRANSLIT", "EUC-JP");
+    iconv(conv,  &inptr, &inleft, &outptr, &outleft);
+
     if (save_is_interactive) {
 	if (init_curses) {
 	    move(ROGUE_LINES - 1, 0);
@@ -177,9 +186,10 @@ clean_up(char *estr)
 	}
 	endwin();
 	printf("\r\n");
-	printf(estr);
+	printf(outbuf);
 	printf("\r\n");
     }
+    free(outbuf);
     md_exit(0);
 }
 


### PR DESCRIPTION
初めまして。
久しぶりにrogueを遊びたくなり、UTF8化され公開されたcloneをありがたく使わせていただいております。

ところで、終了時のメッセージがUTF-8に変換されていないようです。

![bad-encoded-message](https://cloud.githubusercontent.com/assets/27880/22860640/26f9fe4c-f147-11e6-882b-b60d7c4b4a2d.png)

そこで、src/init.c の clean_up()関数にも文字列変換の処理を入れてみました
![utf8-message](https://cloud.githubusercontent.com/assets/27880/22860645/47e7de12-f147-11e6-92c2-96d80ac120fc.png)

これでよろしいようでしたら、マージいただけると幸いです。