### PR TITLE
fix japanese text display and input

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,4 +29,5 @@ rogue_SOURCES = \
 rogue_CFLAGS = \
 	-DJAPAN \
 	-DEUC \
+	-DTERM_UTF8 \
 	-DTOPSCO

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -188,6 +188,7 @@ rogue_SOURCES = \
 rogue_CFLAGS = \
 	-DJAPAN \
 	-DEUC \
+        -DTERM_UTF8 \
 	-DTOPSCO
 
 all: all-am

--- a/src/display.h
+++ b/src/display.h
@@ -4,6 +4,9 @@
 extern void init_color_attr(void);
 extern int put_colorpair_number(char ch);
 extern void get_colorpair_number(char ch, int num);
+extern int utf8len(unsigned char ch);
+extern int convert_eucjp_to_utf8(const char *src, char *dest, size_t dest_size);
+extern int convert_utf8_to_eucjp(const char *src, char *dest, size_t dest_size);
 extern int addch_rogue(const chtype ch);
 extern int mvaddch_rogue(int y, int x, const chtype ch);
 extern int addstr_rogue(const char *str);

--- a/src/init.c
+++ b/src/init.c
@@ -166,6 +166,8 @@ player_init(void)
 void
 clean_up(char *estr)
 {
+    char msg[ROGUE_COLUMNS+1];
+
     if (save_is_interactive) {
 	if (init_curses) {
 	    move(ROGUE_LINES - 1, 0);
@@ -177,7 +179,8 @@ clean_up(char *estr)
 	}
 	endwin();
 	printf("\r\n");
-	printf(estr);
+	convert_eucjp_to_utf8(estr, msg, ROGUE_COLUMNS);
+	printf(msg);
 	printf("\r\n");
     }
     md_exit(0);

--- a/src/play.c
+++ b/src/play.c
@@ -355,7 +355,8 @@ help(void)
     wait_for_ack();
 
     /* 保持した画面を復帰させる */
-    for (lines = 0; lines < ROGUE_LINES; lines++) {
+    clear();
+    for (lines = 1; lines < ROGUE_LINES; lines++) {
 	move(lines, 0);
 	if (lines > 0 && lines < ROGUE_LINES - 1) {
 	    for (columns = 0; columns < ROGUE_COLUMNS; columns++) {
@@ -363,10 +364,7 @@ help(void)
 	    }
 	} else {
 	    /* メッセージデータの最後に末端記号を付加する */
-	    strncpy(disp_message, descs[lines], ROGUE_COLUMNS);
-	    disp_message[ROGUE_COLUMNS] = '\0';
-
-	    addstr_rogue(disp_message);
+	    print_stats(STAT_ALL);
 	}
     }
     refresh();
@@ -561,6 +559,7 @@ void
 doshell(void)
 {
     char *cmd;
+    char msg[ROGUE_COLUMNS+1];
 
     if ((cmd = getenv("SHELL")) == NULL) {
 	cmd = "/bin/sh";
@@ -572,7 +571,8 @@ doshell(void)
 	chdir(org_dir);
     }
     md_ignore_signals();
-    printf(mesg[157]);
+    convert_eucjp_to_utf8(mesg[157], msg, ROGUE_COLUMNS);
+    printf(msg);
     printf("\r\n");
     system(cmd);
     md_heed_signals();


### PR DESCRIPTION
UTF8環境で以下の問題がありましたので、修正してみました。hirakuroさんが2017年に出しているPull Requestとは少し異なるコードになりますが、clean_up()の問題の修正も含んでいます。
iconv()が必要な箇所で漏れていたり、cursesに起因していたりといくつか原因がありました。

1. 設定（"o"キーを押して出る画面）において、「好きな果物」や「ニックネーム」の日本語表示が文字化けする。また、日本語を入力するとエコーバックが正しく表示されない。入力値が不正になる場合がある。
2. 名前をつける("c"キー)でのユーザ入力時に 1. と同様の問題がある。
3. 以下のメッセージが文字化けする。
    - "Q"で終了した後の「それでは、またね。」
    - "o"での設定において、一番下まで入力した時に表示される「＝スペースを押してください＝」
    - その他
4. "h"でヘルプを表示し閉じた後に最下段部の「階」「金塊」「体力」などのステータス表示が文字化けする。
5. "!"でシェルに入った時の「[ シェルを終了するとローグに戻ります ]」のメッセージが文字化けする。

なお、Ctrl+Dでスクリーンショットをファイルに保存できますが日本語は文字化け（正確には文字化けではなく文字データ自体が不正になる）してしまいます。こちらは修正が複雑になりそうなので見送りました。

src/Makefile.amでCFLAGSに"-DTERM_UTF8"を追加する修正を行なっています。内部的にはEUC("-DEUC")だが、表示/入力はUTF-8というふうに考えています。もし"-DTERM_UTF-8"を外してコンパイルすれば表示/入力もEUCとなるため、EUC環境(LANG=ja_JP.eucjp)でも使えるはずです。

Makefile.amを変更しているため、もし採用いただけた場合はautoreconf -iでMakefile.inなども改めて更新した方が良いと思います。

よろしくお願いします。